### PR TITLE
Add exact initializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+.DS_Store
+
 ## User settings
 xcuserdata/
 

--- a/Sources/BFloat16/BFloat16+Conversion.swift
+++ b/Sources/BFloat16/BFloat16+Conversion.swift
@@ -1,0 +1,155 @@
+//
+//  BFloat16+Conversion.swift
+//  BFloat16
+//
+
+extension BinaryInteger {
+  /// Creates an integer from the given `BFloat16`, rounding toward
+  /// zero.
+  ///
+  /// Any fractional part of the value passed as `source` is removed, rounding
+  /// the value toward zero.
+  ///
+  ///     let x = Int(21.5 as BFloat16)
+  ///     // x == 21
+  ///     let y = Int(-21.5 as BFloat16)
+  ///     // y == -21
+  ///
+  /// If `source` is outside the bounds of this type after rounding toward
+  /// zero, a runtime error may occur.
+  ///
+  ///     let z = UInt(-21.5 as BFloat16)
+  ///     // Error: ...the result would be less than UInt.min
+  ///
+  /// - Parameter source: A `BFloat16` value to convert to an integer.
+  ///   `source` must be representable in this type after rounding toward
+  ///   zero.
+  init(_ source: BFloat16) {
+    self = Self(Float(source))
+  }
+  
+  /// Creates an integer from the given `BFloat16`, if it can be
+  /// represented exactly.
+  ///
+  /// If the value passed as `source` is not representable exactly, the result
+  /// is `nil`. In the following example, the constant `x` is successfully
+  /// created from a value of `21.0`, while the attempt to initialize the
+  /// constant `y` from `21.5` fails:
+  ///
+  ///     let x = Int(exactly: 21.0 as BFloat16)
+  ///     // x == Optional(21)
+  ///     let y = Int(exactly: 21.5 as BFloat16)
+  ///     // y == nil
+  ///
+  /// - Parameter source: A `BFloat16` to convert to an integer.
+  init?(exactly source: BFloat16) {
+    guard let value = Self(exactly: Float(source)) else {
+      return nil
+    }
+    
+    self = value
+  }
+}
+
+extension BFloat16 {
+  /// Creates a new instance initialized to the given value, if it can be
+  /// represented without rounding.
+  ///
+  /// If `other` can't be represented as an instance of `BFloat16` without
+  /// rounding, the result of this initializer is `nil`. In particular,
+  /// passing NaN as `other` always results in `nil`.
+  ///
+  /// - Parameter other: The value to use for the new instance.
+  public init?(exactly other: Float) {
+    self = BFloat16(other)
+    guard Float(self) == other else { return nil }
+  }
+  
+  /// Creates a new instance initialized to the given value, if it can be
+  /// represented without rounding.
+  ///
+  /// If `other` can't be represented as an instance of `BFloat16` without
+  /// rounding, the result of this initializer is `nil`. In particular,
+  /// passing NaN as `other` always results in `nil`.
+  ///
+  /// - Parameter other: The value to use for the new instance.
+  public init?(exactly other: Double) {
+    self = BFloat16(other)
+    guard Double(self) == other else { return nil }
+  }
+}
+
+extension Float {
+  /// Creates a new instance initialized to the given value, if it can be
+  /// represented without rounding.
+  ///
+  /// The `Float` type can represent any `BFloat16` value without losing
+  /// precision, but passing NaN as `other` will result in `nil`.
+  ///
+  /// - Parameter other: The value to use for the new instance.
+  public init?(exactly other: BFloat16) {
+    guard !other.isNaN else { return nil }
+    self = Float(other)
+  }
+}
+
+extension Double {
+  /// Creates a new instance that approximates the given value.
+  /// - Parameter other: The value to use for the new instance.
+  public init(_ other: BFloat16) {
+    self.init(Float(other))
+  }
+  
+  /// Creates a new instance initialized to the given value, if it can be
+  /// represented without rounding.
+  ///
+  /// If `other` can't be represented as an instance of `Double` without
+  /// rounding, the result of this initializer is `nil`. In particular,
+  /// passing NaN as `other` always results in `nil`.
+  ///
+  /// - Parameter other: The value to use for the new instance.
+  public init?(exactly other: BFloat16) {
+    self = Double(other)
+    guard BFloat16(self) == other else { return nil }
+  }
+}
+
+#if canImport(Foundation)
+import Foundation
+
+extension BFloat16 {
+  /// Creates a new instance initialized to the given value, if it can be
+  /// represented without rounding.
+  ///
+  /// If `other` can't be represented as an instance of `BFloat16` without
+  /// rounding, the result of this initializer is `nil`. In particular,
+  /// passing NaN as `other` always results in `nil`.
+  ///
+  /// - Parameter other: The value to use for the new instance.
+  public init?(exactly other: CGFloat) {
+    self = BFloat16(other)
+    guard CGFloat(self) == other else { return nil }
+  }
+}
+
+extension CGFloat {
+  /// Creates a new instance that approximates the given value.
+  /// - Parameter other: The value to use for the new instance.
+  public init(_ other: BFloat16) {
+    self.init(NativeType(other))
+  }
+  
+  /// Creates a new instance initialized to the given value, if it can be
+  /// represented without rounding.
+  ///
+  /// If `other` can't be represented as an instance of `Double` without
+  /// rounding, the result of this initializer is `nil`. In particular,
+  /// passing NaN as `other` always results in `nil`.
+  ///
+  /// - Parameter other: The value to use for the new instance.
+  public init?(exactly other: BFloat16) {
+    self.init(NativeType(other))
+    guard BFloat16(self) == other else { return nil }
+  }
+}
+#endif

--- a/Sources/BFloat16/BFloat16+Numeric.swift
+++ b/Sources/BFloat16/BFloat16+Numeric.swift
@@ -25,10 +25,9 @@ extension BFloat16: AdditiveArithmetic {
 
 extension BFloat16: Numeric {
   public init?<T>(exactly source: T) where T : BinaryInteger {
-    guard let val = Float(exactly: source) else {
-      return nil
-    }
-    self = BFloat16(val)
+    guard let float = Float(exactly: source),
+          let result = BFloat16(exactly: float) else { return nil }
+    self = result
   }
 
   public var magnitude: BFloat16 {

--- a/Tests/BFloat16Tests/BFloat16Tests.swift
+++ b/Tests/BFloat16Tests/BFloat16Tests.swift
@@ -6,6 +6,7 @@
 //
 import SwiftCheck
 import XCTest
+import Foundation
 
 @testable import BFloat16
 
@@ -98,16 +99,30 @@ final class BFloat16Tests: XCTestCase {
     XCTAssertEqual(BFloat16.negativeZero.sign, .minus)
     XCTAssertEqual(BFloat16.infinity, BFloat16(Float.infinity))
     XCTAssertEqual(-BFloat16.infinity, BFloat16(-Float.infinity))
+      
+    XCTAssertEqual(BFloat16(exactly: 200 as Int), BFloat16(200.0))
+    XCTAssertEqual(BFloat16(exactly: Float(7.5)), BFloat16(7.5))
+    XCTAssertEqual(BFloat16(exactly: Double(7.5)), BFloat16(7.5))
+    XCTAssertEqual(BFloat16(exactly: CGFloat(7.5)), BFloat16(7.5))
+    XCTAssertNil(BFloat16(exactly: 7.0001 as Float))
 
     XCTAssertEqual(BFloat16(-Float(1.0)).sign, .minus)
     XCTAssertEqual(BFloat16(Float(1.0)).sign, .plus)
     XCTAssert(BFloat16(Float.nan).isNaN)
+    XCTAssertNil(BFloat16(exactly: Float.nan))
+    XCTAssertNil(BFloat16(exactly: Double.nan))
+    XCTAssertNil(BFloat16(exactly: CGFloat.nan))
   }
 
   func testToFloat() {
     let exact = BFloat16(7.0)
     XCTAssertEqual(Float(exact), 7.0)
 
+    XCTAssertEqual(Float(exactly: exact), Float(exact))
+    XCTAssertEqual(CGFloat(exactly: exact), CGFloat(exact))
+    XCTAssertEqual(Float(Double(exact)), Float(exact))
+    XCTAssertEqual(Double(exactly: exact), Double(exact))
+      
     // 7.1 is NOT exactly representable in 16-bit, it's rounded
     let inexact = BFloat16(7.1)
     let diff = abs(Float(inexact) - 7.1)
@@ -120,6 +135,21 @@ final class BFloat16Tests: XCTestCase {
 
     XCTAssertEqual(BFloat16(bitPattern: 0x0001), BFloat16(tinyFloat))
     XCTAssertEqual(BFloat16(bitPattern: 0x0005), BFloat16(5.0 * tinyFloat))
+      
+    XCTAssertNil(Float(exactly: BFloat16.nan))
+    XCTAssertNil(Double(exactly: BFloat16.nan))
+    XCTAssertNil(CGFloat(exactly: BFloat16.nan))
+  }
+    
+  func testToInt() {
+    let exact = BFloat16(7.0)
+    XCTAssertEqual(Int(exact), 7)
+    XCTAssertEqual(Int(exactly: exact), 7)
+      
+    let inexact = BFloat16(6.5)
+    XCTAssertEqual(Int(inexact), 6)
+    XCTAssertNil(Int(exactly: inexact))
+    XCTAssertNil(Int(exactly: BFloat16.nan))
   }
 
   func testNan() {


### PR DESCRIPTION
This adds the `init(exactly:)` initializers common to all Floating point types, and also overrides some built-in conversions which were failing.