### PR TITLE
Add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
     .target(
       name: "BFloat16",
       dependencies: ["bfloat16_c"],
+      resources: [.process("PrivacyInfo.xcprivacy")]
     ),
     .testTarget(
       name: "BFloat16Tests",

--- a/Sources/BFloat16/PrivacyInfo.xcprivacy
+++ b/Sources/BFloat16/PrivacyInfo.xcprivacy
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
Apple wants each library that is executed on a user's iPhone to include a privacy manifest, but this project is simple enough to leave the manifest empty.