### PR TITLE
Add conformance to AtomicRepresentable

### DIFF
--- a/Sources/BFloat16/BFloat16+Atomic.swift
+++ b/Sources/BFloat16/BFloat16+Atomic.swift
@@ -1,0 +1,19 @@
+//
+//  BFloat16+Atomic.swift
+//  BFloat16
+//
+
+#if canImport(Synchronization)
+import Synchronization
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension BFloat16: AtomicRepresentable {
+    public static func encodeAtomicRepresentation(_ value: BFloat16) -> UInt16.AtomicRepresentation {
+        UInt16.encodeAtomicRepresentation(value.bitPattern)
+    }
+    
+    public static func decodeAtomicRepresentation(_ storage: consuming UInt16.AtomicRepresentation) -> BFloat16 {
+        BFloat16(bitPattern: UInt16.decodeAtomicRepresentation(storage))
+    }
+}
+#endif

--- a/Tests/BFloat16Tests/BFloat16Tests.swift
+++ b/Tests/BFloat16Tests/BFloat16Tests.swift
@@ -248,6 +248,19 @@ final class BFloat16Tests: XCTestCase {
         }
       }
   }
+    
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func testRoundtripAtomic() {
+    property("BFloat16 roundtrip identity check")
+      <- forAll { (val: BFloat16) in
+        let roundtrip = BFloat16.decodeAtomicRepresentation(BFloat16.encodeAtomicRepresentation(val))
+        if val.isNaN {
+          return roundtrip.isNaN && val.sign == roundtrip.sign
+        } else {
+          return val == roundtrip
+        }
+      }
+  }
 
   func testUnaryOperations() {
     property("BFloat16 unary ops")


### PR DESCRIPTION
This allows `BFloat16` to be used in an `Atomic` wrapper. It functions identically to atomic operations on the built-in floating number types, i.e. only compare-exchange and loads/stores are allowed.