### PR TITLE
Add conformance to BNNSScalar

### DIFF
--- a/Sources/BFloat16/BFloat16+BNNS.swift
+++ b/Sources/BFloat16/BFloat16+BNNS.swift
@@ -1,0 +1,23 @@
+//
+//  BFloat16+BNNS.swift
+//  BFloat16
+//
+
+#if canImport(Accelerate)
+import Accelerate
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+extension BFloat16: BNNSScalar {
+    @_transparent @inlinable @inline(__always)
+    public static var bnnsDataType: BNNSDataType { .bfloat16 }
+}
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+extension BNNSDataType {
+    @_transparent @inlinable @inline(__always)
+    /// Equivalent to `BNNSDataTypeBFloat16`.
+    public static var bfloat16: BNNSDataType {
+        BNNSDataTypeBFloat16
+    }
+}
+#endif


### PR DESCRIPTION
BNNS is a library built into all Apple devices, that focuses on creating neural networks. It actually supports BFloat16, despite not having a Swift type for it.

This PR adds a conformance that makes use of this constant, and adds a shorthand for `bfloat16`, similar to the first-class data types.

See https://developer.apple.com/documentation/accelerate/bnnsdatatype