### PR TITLE
Remove excess if-statement in Decoder

### DIFF
--- a/Sources/BFloat16/BFloat16+Codable.swift
+++ b/Sources/BFloat16/BFloat16+Codable.swift
@@ -27,15 +27,6 @@ extension BFloat16: Codable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     let float = try container.decode(Float.self)
-
-    guard float.isInfinite || float.isNaN || abs(float) <= Float(BFloat16.greatestFiniteMagnitude)
-    else {
-      throw DecodingError.dataCorrupted(
-        DecodingError.Context(
-          codingPath: container.codingPath,
-          debugDescription: "Parsed number \(float) does not fit in \(type(of: self))."))
-    }
-
     self.init(float)
   }
 }

--- a/Tests/BFloat16Tests/BFloat16Tests.swift
+++ b/Tests/BFloat16Tests/BFloat16Tests.swift
@@ -45,6 +45,8 @@ final class BFloat16Tests {
     #expect(BFloat16.negativeZero.sign == .minus)
     #expect(BFloat16.infinity == BFloat16(Float.infinity))
     #expect(-BFloat16.infinity == BFloat16(-Float.infinity))
+    #expect(BFloat16(Float.greatestFiniteMagnitude) == BFloat16.infinity)
+    #expect(BFloat16(-Float.greatestFiniteMagnitude) == -BFloat16.infinity)
 
     #expect(BFloat16(exactly: 200 as Int) == BFloat16(200.0))
     #expect(BFloat16(exactly: Float(7.5)) == BFloat16(7.5))


### PR DESCRIPTION
The check for data corruption was copied from the implementation of the Half (or regular Float16) type, which has a much smaller upper bound than BFloat16 does. Since the maximum Float value is nearly identical to BFloat16's maximum value, I think it's acceptable to remove this check.